### PR TITLE
Why Feather Partner

### DIFF
--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,4 +1,4 @@
-name: FeatherPartner
+name: FeatherPlugin
 main: net.digitalingot.featherpartner.platforms.bungee.FeatherBungee
 version: '1.0'
 author: DigitalIngot


### PR DESCRIPTION
Why FeatherPartner in bungee.yml? In the plugin.yml it is called FeatherPlugin.