### PR TITLE
Change the bungee.yml

### DIFF
--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,4 +1,4 @@
-name: FeatherPartner
+name: FeatherPlugin
 main: net.digitalingot.featherpartner.platforms.bungee.FeatherBungee
 version: '1.0'
 author: DigitalIngot

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,6 +1,4 @@
 name: FeatherPlugin
-main: net.digitalingot.featherpartner.platforms.bungee.FeatherBungee
+main: net.digitalingot.featherplugin.platforms.bungee.FeatherBungee
 version: '1.0'
 author: DigitalIngot
-softdepends:
-  - LuckPerms


### PR DESCRIPTION
Why FeatherPartner? In the plugin.yml it is called FeatherPlugin.